### PR TITLE
Show notice + explanatory content for `v2` if JS is disabled.

### DIFF
--- a/v2.html
+++ b/v2.html
@@ -29,6 +29,24 @@
             padding: 10px 0 10px 0;
             font-size: 2.2em;
         }
+        .notice {
+            background-color: red;
+            color: white;
+            padding: 10px 0 10px 0;
+            font-size: 1.25em;
+            animation: flash 4s infinite;
+        }
+        @keyframes flash {
+          0% {
+            background-color: red;
+          }
+          50% {
+            background-color: #AA0000;
+          }
+          0% {
+            background-color: red;
+          }
+        }
         <!-- CSS from Mark Webster https://gist.github.com/markcwebster/9bdf30655cdd5279bad13993ac87c85d -->
         </style>
 
@@ -41,7 +59,13 @@
         </script>
     </head>
     <body>
-
+    <noscript>
+        <div class="notice">
+            <div class="container">
+                ⚠️ JavaScript appears to be disabled. NeverSSL's cache-busting works better if you enable JavaScript for <code>neverssl.com</code>.
+            </div>
+        </div>
+    </noscript>
     <div class="header">
         <div class="container">
         <h1>NeverSSL</h1>
@@ -51,7 +75,41 @@
     <div class="content">
     <div class="container">
 
-    <h1>Connecting ...</h1>
+    <h1 id="status"></h1>
+    <script>document.querySelector("#status").textContent = "Connecting ...";</script>
+    <noscript>
+
+        <h2>What?</h2>
+        <p>This website is for when you try to open Facebook, Google, Amazon, etc
+        on a wifi network, and nothing happens. Type "http://neverssl.com"
+        into your browser's url bar, and you'll be able to log on.</p>
+
+        <h2>How?</h2>
+        <p>neverssl.com will never use SSL (also known as TLS). No
+        encryption, no strong authentication, no <a
+        href="https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security">HSTS</a>,
+        no HTTP/2.0, just plain old unencrypted HTTP and forever stuck in the dark
+        ages of internet security.</p> 
+
+        <h2>Why?</h2>
+        <p>Normally, that's a bad idea. You should always use SSL and secure
+        encryption when possible. In fact, it's such a bad idea that most websites
+        are now using https by default.</p>
+        
+        <p>And that's great, but it also means that if you're relying on
+        poorly-behaved wifi networks, it can be hard to get online.  Secure
+        browsers and websites using https make it impossible for those wifi
+        networks to send you to a login or payment page. Basically, those networks
+        can't tap into your connection just like attackers can't. Modern browsers
+        are so good that they can remember when a website supports encryption and
+        even if you type in the website name, they'll use https.</p> 
+
+        <p>And if the network never redirects you to this page, well as you can
+        see, you're not missing much.</p>
+
+        <a href="https://twitter.com/neverssl?ref_src=twsrc%5Etfw" class="twitter-follow-button" data-size="large" data-show-count="false">Follow @neverssl</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+    </noscript>
 
     </div>
     </div>


### PR DESCRIPTION
Screenshot:

<img width="1219" alt="Screen Shot 2019-06-06 at 15 02 28" src="https://user-images.githubusercontent.com/248078/59069613-950ccb80-886c-11e9-8ba2-6bfb21e7fd6a.png">

The background color of the red notice at the top pulses gently between bright red and darker red.